### PR TITLE
Fix A11y in the demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,16 +11,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
 
-  <title>iron-iconset</title>
+  <title>iron-iconset demo</title>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../iron-iconset.html">
   <link rel="import" href="../../iron-icon/iron-icon.html">
-
+  <link rel="import" href="../../paper-styles/demo-pages.html">
+  <style>
+    iron-icon {
+      margin: 5px;
+    }
+  </style>
 </head>
 <body>
-
   <!-- Register an icon set; you can do this anywhere, including an HTMLImport! -->
   <iron-iconset name="my-icons" src="my-icons.png" width="96" size="24"
       icons="location place starta stopb bus car train walk">
@@ -30,33 +34,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       icons="location place starta stopb bus car train walk">
   </iron-iconset>
 
-  <!-- Now create a bunch of icons using our iconset -->
-  <iron-icon icon="my-icons:location"></iron-icon>
-  <iron-icon icon="my-icons:place"></iron-icon>
-  <iron-icon icon="my-icons:starta"></iron-icon>
-  <iron-icon icon="my-icons:stopb"></iron-icon>
-  <iron-icon icon="my-icons:bus"></iron-icon>
-  <iron-icon icon="my-icons:car"></iron-icon>
-  <iron-icon icon="my-icons:train"></iron-icon>
-  <iron-icon icon="my-icons:walk"></iron-icon>
-  <br>
-  <!-- icons may also be specified by index -->
-  <style>
-    .embiggen iron-icon {
-      width: 48px;
-      height: 48px;
-    }
-  </style>
-
-  <div class="embiggen">
-    <iron-icon icon="my-icons-big:0"></iron-icon>
-    <iron-icon icon="my-icons-big:1"></iron-icon>
-    <iron-icon icon="my-icons-big:2"></iron-icon>
-    <iron-icon icon="my-icons-big:3"></iron-icon>
-    <iron-icon icon="my-icons-big:4"></iron-icon>
-    <iron-icon icon="my-icons-big:5"></iron-icon>
-    <iron-icon icon="my-icons-big:6"></iron-icon>
-    <iron-icon icon="my-icons-big:7"></iron-icon>
+  <div class="vertical-section vertical-section-container centered">
+    <!-- Now create a bunch of icons using our iconset -->
+    <h4>Small icon set</h4>
+    <div>
+      <iron-icon icon="my-icons:location"></iron-icon>
+      <iron-icon icon="my-icons:place"></iron-icon>
+      <iron-icon icon="my-icons:starta"></iron-icon>
+      <iron-icon icon="my-icons:stopb"></iron-icon>
+      <iron-icon icon="my-icons:bus"></iron-icon>
+      <iron-icon icon="my-icons:car"></iron-icon>
+      <iron-icon icon="my-icons:train"></iron-icon>
+      <iron-icon icon="my-icons:walk"></iron-icon>
+    </div>
+    <br>
+    <h4>Big icon set with labels</h4>
+    <div class="embiggen">
+      <iron-icon icon="my-icons-big:0"></iron-icon>
+      <iron-icon icon="my-icons-big:1"></iron-icon>
+      <iron-icon icon="my-icons-big:2"></iron-icon>
+      <iron-icon icon="my-icons-big:3"></iron-icon>
+      <iron-icon icon="my-icons-big:4"></iron-icon>
+      <iron-icon icon="my-icons-big:5"></iron-icon>
+      <iron-icon icon="my-icons-big:6"></iron-icon>
+      <iron-icon icon="my-icons-big:7"></iron-icon>
+    </div>
+    <br>
+    <h4>Accessible icon set with labels</h4>
+    <div>
+      <iron-icon icon="my-icons:location" tabindex="0" aria-label="icon: location"></iron-icon>
+      <iron-icon icon="my-icons:place" tabindex="0" aria-label="icon: place"></iron-icon>
+      <iron-icon icon="my-icons:starta" tabindex="0" aria-label="icon: start a"></iron-icon>
+      <iron-icon icon="my-icons:stopb" tabindex="0" aria-label="icon: stop b"></iron-icon>
+      <iron-icon icon="my-icons:bus" tabindex="0" aria-label="icon: bus"></iron-icon>
+      <iron-icon icon="my-icons:car" tabindex="0" aria-label="icon: car"></iron-icon>
+      <iron-icon icon="my-icons:train" tabindex="0" aria-label="icon: train"></iron-icon>
+      <iron-icon icon="my-icons:walk" tabindex="0" aria-label="icon: walk"></iron-icon>
+    </div>
   </div>
 
  </body>


### PR DESCRIPTION
Relevant for https://github.com/PolymerElements/iron-iconset/issues/7 and https://github.com/PolymerElements/iron-iconset/issues/4.

I still think that we should fix the image for the icons specially for the big icons, so they look better on retina display.

<img width="581" alt="screen shot 2015-09-25 at 4 46 16 pm" src="https://cloud.githubusercontent.com/assets/1410613/10114405/f9cf31a2-63a4-11e5-80d0-bb19ef722d8d.png">


/cc @notwaldorf @frankiefu 
