### PR TITLE
Dispatch an event on window when the iconset loads.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
     "iron-icon": "polymerelements/iron-icon#^1.0.0",
+    "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "*",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"

--- a/iron-iconset.html
+++ b/iron-iconset.html
@@ -236,6 +236,9 @@ Then a themed icon can be applied like this:
 
     _prepareIconset: function() {
       new Polymer.IronMeta({type: 'iconset', key: this.name, value: this});
+      this.async(function() {
+        this.fire('iron-iconset-added', this, {node: window});
+      });
     },
 
     _invalidateIconMap: function() {

--- a/test/iron-iconset.html
+++ b/test/iron-iconset.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../iron-iconset.html">
   <link rel="import" href="../../iron-meta/iron-meta.html">
+  <link rel="import" href="../../promise-polyfill/promise-polyfill.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
 
 </head>
@@ -63,8 +64,17 @@ suite('<iron-iconset>', function () {
   suite('basic behavior', function () {
     var iconset;
     var meta;
+    var loadedPromise;
 
     setup(function () {
+      loadedPromise = new Promise(function(resolve) {
+        window.addEventListener('iron-iconset-added', function(ev) {
+          if (ev && ev.detail === iconset) {
+            resolve();
+          }
+        });
+      });
+
       var elements = fixture('TrivialIconset');
 
       iconset = elements[0];
@@ -73,6 +83,10 @@ suite('<iron-iconset>', function () {
 
     test('it can be accessed via iron-meta', function () {
       expect(meta.byKey('foo')).to.be.equal(iconset);
+    });
+
+    test('it fires an iron-iconset-added event on the window', function() {
+      return loadedPromise;
     });
   });
 


### PR DESCRIPTION
This will enable iron-icons to detect when an iconset loads after the icon element itself.

Related to https://github.com/PolymerElements/iron-icons/issues/18

Pretty much line for line the same as https://github.com/PolymerElements/iron-iconset-svg/pull/25