### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/iron-iconset.js
+++ b/iron-iconset.js
@@ -71,6 +71,7 @@ import {dom} from '@polymer/polymer/lib/legacy/polymer.dom.js';
 Polymer({
 
   is: 'iron-iconset',
+  _template: null,
 
   properties: {
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336